### PR TITLE
Partition Assignment Aware Kafka Consumer

### DIFF
--- a/src/main/java/com/rackspace/salus/event/processor/config/AppProperties.java
+++ b/src/main/java/com/rackspace/salus/event/processor/config/AppProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.processor.config;
+
+import java.time.Duration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties("salus.event-processor")
+@Component
+@Data
+@Validated
+public class AppProperties {
+
+  /**
+   * Whether the metrics consumer should begin automatically on service startup
+   */
+  Boolean kafkaListenerAutoStart = true;
+
+  /**
+   * The time to wait after a partition reassignment before taking action.
+   *
+   * The value should be set large enough to allow for normal amounts of partition shuffling
+   * when a new consumer is added into the group and/or an existing one goes offline.
+   *
+   * In production it could be set to 1min or greater.
+   */
+  Duration partitionAssignmentDelay = Duration.ofSeconds(60);
+}

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
@@ -108,6 +108,8 @@ public class UniversalMetricHandler {
     List<EventEngineTask> tasksToUndeploy = new ArrayList<>();
     for (Integer partition : removedPartitions) {
       List<EventEngineTask> tasks = taskRepository.findByPartition(partition);
+      // TODO this might need to be pageable?
+      // Similar to https://github.com/racker/salus-telemetry-monitor-management/pull/219
       tasksToUndeploy.addAll(tasks);
     }
     log.info("TODO Remove tasks from {}", tasksToUndeploy);
@@ -124,6 +126,8 @@ public class UniversalMetricHandler {
     List<EventEngineTask> tasksToDeploy = new ArrayList<>();
     for (Integer partition : addedPartitions) {
       List<EventEngineTask> tasks = taskRepository.findByPartition(partition);
+      // TODO this might need to be pageable?
+      // Similar to https://github.com/racker/salus-telemetry-monitor-management/pull/219
       tasksToDeploy.addAll(tasks);
     }
     log.info("TODO deploy tasks from {}", tasksToDeploy);

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
@@ -20,6 +20,11 @@ import com.rackspace.monplat.protocol.UniversalMetricFrame;
 import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.event.processor.engine.EsperEngine;
 import com.rackspace.salus.event.processor.model.SalusEnrichedMetric;
+import com.rackspace.salus.telemetry.entities.EventEngineTask;
+import com.rackspace.salus.telemetry.repositories.EventEngineTaskRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +49,7 @@ public class UniversalMetricHandler {
   private static final String SALUS_MONITOR_SELECTOR_SCOPE = "monitor_selector_scope";
 
   EsperEngine esperEngine;
+  EventEngineTaskRepository taskRepository;
 
   @Autowired
   public UniversalMetricHandler(EsperEngine esperEngine) {
@@ -89,5 +95,37 @@ public class UniversalMetricHandler {
         .setTenantId(tenantId)
         .setAccountType(accountType)
         .setMetrics(universalMetric.getMetricsList());
+  }
+
+  /**
+   * Undeploys all tasks from esper related to the provided partitions.
+   *
+   * @param removedPartitions The partitions whose alarms will be undeployed.
+   */
+  public void removeTasksForPartitions(Set<Integer> removedPartitions) {
+    log.info("Removing tasks from engine for {} partitions", removedPartitions.size());
+    // load from db and then undeploy
+    List<EventEngineTask> tasksToUndeploy = new ArrayList<>();
+    for (Integer partition : removedPartitions) {
+      List<EventEngineTask> tasks = taskRepository.findByPartition(partition);
+      tasksToUndeploy.addAll(tasks);
+    }
+    log.info("TODO Remove tasks from {}", tasksToUndeploy);
+  }
+
+  /**
+   * Deploys all tasks to esper related to the provided partitions.
+   *
+   * @param addedPartitions The partitions whose alarms will be deployed.
+   */
+  public void deployTasksForPartitions(Set<Integer> addedPartitions) {
+    log.info("Adding tasks to engine for {} partitions", addedPartitions.size());
+    // load from db and then deploy
+    List<EventEngineTask> tasksToDeploy = new ArrayList<>();
+    for (Integer partition : addedPartitions) {
+      List<EventEngineTask> tasks = taskRepository.findByPartition(partition);
+      tasksToDeploy.addAll(tasks);
+    }
+    log.info("TODO deploy tasks from {}", tasksToDeploy);
   }
 }

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
@@ -124,7 +124,7 @@ public class UniversalMetricHandler {
   public void deployTasksForPartitions(Set<Integer> addedPartitions) {
     log.info("Adding tasks to engine for {} partitions", addedPartitions.size());
     // load from db and then deploy
-    List<SalusEventEngineTask> tasksToDeploy = new ArrayList<>();
+    List<EventEngineTask> tasksToDeploy = new ArrayList<>();
     for (Integer partition : addedPartitions) {
       List<SalusEventEngineTask> tasks = salusTaskRepository.findByPartition(partition);
       tasksToDeploy.addAll(tasks);

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricListener.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricListener.java
@@ -16,29 +16,58 @@
 
 package com.rackspace.salus.event.processor.services;
 
+import com.google.common.collect.Sets;
 import com.rackspace.monplat.protocol.UniversalMetricFrame;
 import com.rackspace.monplat.protocol.UniversalMetricFrame.MonitoringSystem;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.kafka.common.TopicPartition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.ConsumerSeekAware;
+import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-public class UniversalMetricListener {
+public class UniversalMetricListener implements ConsumerSeekAware {
+
+  // todo make this a config parameter
+  public static final Duration partitionAssignmentDelay = Duration.ofSeconds(5);
+
+  private Set<Integer> trackedPartitions;
+  private ScheduledFuture<?> scheduledPartitionChangeTask;
+  private final String consumerId;
+
+  ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
   private final UniversalMetricHandler handler;
-  private final KafkaTopicProperties properties;
   private final String topic;
+  private final KafkaListenerEndpointRegistry registry;
 
   @Autowired
   public UniversalMetricListener(
       UniversalMetricHandler handler,
-      KafkaTopicProperties properties) {
+      KafkaTopicProperties properties,
+      KafkaListenerEndpointRegistry registry) {
     this.handler = handler;
-    this.properties = properties;
     this.topic = properties.getMetrics();
+    this.registry = registry;
+    this.trackedPartitions = Sets.newConcurrentHashSet();
+    this.consumerId = RandomStringUtils.randomAlphabetic(10);
   }
 
   /**
@@ -51,16 +80,113 @@ public class UniversalMetricListener {
   }
 
   /**
+   * This method is used by the __listener.topic magic in the KafkaListener
+   *
+   * @return The unique consumerId
+   */
+  public String getConsumerId() {
+    return consumerId;
+  }
+
+  /**
    * This receives a UniversalMetricFrame event from Kafka and passes it on to
    * another service to process it.
    *
    * @param metric The UniversalMetricFrame read from Kafka.
    */
-  @KafkaListener(topics = "#{__listener.topic}")
+  @KafkaListener(
+      autoStartup = "${salus.kafka-listener-auto-start:true}",
+      id = "#{__listener.consumerId}",
+      groupId = "${spring.kafka.consumer.group-id}",
+      topics = "#{__listener.topic}",
+      // override the default partition assignor to limit reassignment overhead
+      properties = {"partition.assignment.strategy=org.apache.kafka.clients.consumer.StickyAssignor"})
   public void consumeUniversalMetrics(UniversalMetricFrame metric) {
     log.debug("Processing kapacitor event: {}", metric);
     if (metric.getMonitoringSystem().equals(MonitoringSystem.SALUS)) {
       handler.processSalusMetricFrame(metric);
     }
+  }
+
+  @Override
+  public void onPartitionsAssigned(Map<TopicPartition, Long> assignments,
+      ConsumerSeekCallback callback) {
+    log.debug("Partitions Assigned to consumer={}: {}",
+        getConsumerId(),
+        assignments.keySet().stream()
+            .map(TopicPartition::partition)
+            .collect(Collectors.toSet()));
+
+    schedulePartitionReload();
+  }
+
+  @Override
+  public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    log.debug("Partitions Revoked from consumer={}: {}",
+        getConsumerId(),
+        partitions.stream()
+            .map(TopicPartition::partition)
+            .collect(Collectors.toSet()));
+
+    schedulePartitionReload();
+  }
+
+  private void schedulePartitionReload() {
+    if (scheduledPartitionChangeTask != null && !scheduledPartitionChangeTask.isDone()) {
+      scheduledPartitionChangeTask.cancel(false);
+    }
+    scheduledPartitionChangeTask = executorService.schedule(
+        this::reloadPartitions,
+        partitionAssignmentDelay.toSeconds(),
+        TimeUnit.SECONDS);
+  }
+
+  /**
+   * Determine which partitions were removed and which were added.
+   *
+   * Remove deployed tasks for the removed partitions.
+   * Deploy new tasks for the added partitions.
+   */
+  private void reloadPartitions() {
+    log.info("Reloading changed partitions");
+    Set<Integer> assignedPartitions = getCurrentAssignedPartitions();
+
+    Set<Integer> removedPartitions = new HashSet<>(trackedPartitions);
+    removedPartitions.removeAll(assignedPartitions);
+
+    Set<Integer> addedPartitions = new HashSet<>(assignedPartitions);
+    addedPartitions.removeAll(trackedPartitions);
+
+    trackedPartitions = assignedPartitions;
+
+    handler.removeTasksForPartitions(removedPartitions);
+    handler.deployTasksForPartitions(addedPartitions);
+  }
+
+  Set<Integer> getCurrentAssignedPartitions() {
+    MessageListenerContainer container = registry.getListenerContainer(consumerId);
+    if (container == null) {
+      return Collections.emptySet();
+    }
+    Collection<TopicPartition> assignments = container.getAssignedPartitions();
+    if (assignments == null) {
+      return Collections.emptySet();
+    }
+
+    return assignments.stream()
+        .map(TopicPartition::partition)
+        .collect(Collectors.toSet());
+  }
+
+  Set<Integer> getTrackedPartitions() {
+    return this.trackedPartitions;
+  }
+
+  void stop() {
+    this.registry.getListenerContainer(consumerId).stop();
+  }
+
+  void start() {
+    this.registry.getListenerContainer(consumerId).start();
   }
 }

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricListener.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricListener.java
@@ -181,15 +181,38 @@ public class UniversalMetricListener implements ConsumerSeekAware {
         .collect(Collectors.toSet());
   }
 
+  /**
+   * Get the set of partitions the processor is handling tasks for.
+   *
+   * @return A set of partition ids.
+   */
   Set<Integer> getTrackedPartitions() {
     return this.trackedPartitions;
   }
 
+  /**
+   * Currently only used in tests.
+   */
   void stop() {
-    this.registry.getListenerContainer(listenerId).stop();
+    MessageListenerContainer container = registry.getListenerContainer(listenerId);
+    if (container != null) {
+      log.info("Stopping kafka listener container id={}", listenerId);
+      container.stop();
+    } else {
+      log.error("Could not stop kafka listener. No container found with id={}", listenerId);
+    }
   }
 
+  /**
+   * Currently only used in tests.
+   */
   void start() {
-    this.registry.getListenerContainer(listenerId).start();
+    MessageListenerContainer container = registry.getListenerContainer(listenerId);
+    if (container != null) {
+      log.info("Starting kafka listener container id={}", listenerId);
+      container.start();
+    } else {
+      log.error("Could not start kafka listener. No container found with id={}", listenerId);
+    }
   }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+salus:
+  kafka-listener-auto-start: false
+logging:
+  level:
+    com.rackspace.salus: debug

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,5 +1,8 @@
 salus:
-  kafka-listener-auto-start: false
+  event-processor:
+    kafka-listener-auto-start: false
+    partition-assignment-delay: "PT5S"
+
 logging:
   level:
     com.rackspace.salus: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 salus:
   environment: local
-  kafka-listener-auto-start: true
+  event-processor:
+    kafka-listener-auto-start: true
 spring:
   kafka:
     producer:
@@ -12,18 +13,11 @@ spring:
       auto-offset-reset: latest
       properties:
         spring.deserializer.value.delegate.class: com.rackspace.monplat.protocol.UniversalMetricFrameDeserializer
-  jpa:
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
-    properties:
-      hibernate:
-        generate_statistics: false
-    show-sql: false
-  datasource:
-    username: dev
-    password: pass
-    url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    platform: mysql
+  jackson:
+    mapper:
+      default-view-inclusion: true
+  zipkin:
+    enabled: false
 management:
   metrics:
     export:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 salus:
   environment: local
+  kafka-listener-auto-start: true
 spring:
   kafka:
     producer:
@@ -11,6 +12,18 @@ spring:
       auto-offset-reset: latest
       properties:
         spring.deserializer.value.delegate.class: com.rackspace.monplat.protocol.UniversalMetricFrameDeserializer
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    properties:
+      hibernate:
+        generate_statistics: false
+    show-sql: false
+  datasource:
+    username: dev
+    password: pass
+    url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    platform: mysql
 management:
   metrics:
     export:

--- a/src/test/java/com/rackspace/salus/event/processor/engine/EsperQueryTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/engine/EsperQueryTest.java
@@ -39,11 +39,13 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {
     EsperEngine.class, SimpleMeterRegistry.class, ObjectMapper.class})
+@ActiveProfiles("test")
 public class EsperQueryTest {
 
   @Autowired

--- a/src/test/java/com/rackspace/salus/event/processor/services/EsperEventsHandlerTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/EsperEventsHandlerTest.java
@@ -52,6 +52,7 @@ import org.springframework.boot.autoconfigure.cache.CacheType;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/rackspace/salus/event/processor/services/EsperEventsHandlerTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/EsperEventsHandlerTest.java
@@ -52,7 +52,6 @@ import org.springframework.boot.autoconfigure.cache.CacheType;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
@@ -40,8 +40,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
-import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback;
-import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -101,14 +99,8 @@ public class UniversalMetricListenerTest {
   @Qualifier("consumer3")
   UniversalMetricListener consumer3;
 
-  @Autowired
-  EmbeddedKafkaBroker embeddedKafka;
-
   @MockBean
   UniversalMetricHandler handler;
-
-  @MockBean
-  ConsumerSeekCallback consumerSeek;
 
   @Test
   public void testInitialStartup_1consumer() {

--- a/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.processor.services;
+
+import static com.rackspace.salus.event.processor.services.UniversalMetricListener.partitionAssignmentDelay;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.event.processor.services.UniversalMetricListenerTest.TestConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@EmbeddedKafka(partitions = 3, topics = {"telemetry.metrics.json"})
+@SpringBootTest(
+    properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+    classes = {KafkaAutoConfiguration.class, TestConfig.class, KafkaTopicProperties.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+public class UniversalMetricListenerTest {
+
+  @TestConfiguration
+  public static class TestConfig {
+    @MockBean
+    UniversalMetricHandler handler;
+
+    @Autowired
+    KafkaTopicProperties properties;
+
+    // all consumers will share a registry, but that's ok
+    // because they only look up info in their unique container
+    @Autowired
+    KafkaListenerEndpointRegistry registry;
+
+    @Bean
+    UniversalMetricListener consumer1() {
+      return new UniversalMetricListener(handler, properties, registry);
+    }
+
+    @Bean
+    UniversalMetricListener consumer2() {
+      return new UniversalMetricListener(handler, properties, registry);
+    }
+
+    @Bean
+    UniversalMetricListener consumer3() {
+      return new UniversalMetricListener(handler, properties, registry);
+    }
+  }
+
+  // increase the delay to help slow laptops running tests locally
+  long testTimeout = partitionAssignmentDelay.plus(Duration.ofSeconds(3)).toMillis();
+
+  @Autowired
+  @Qualifier("consumer1")
+  UniversalMetricListener consumer1;
+
+  @Autowired
+  @Qualifier("consumer2")
+  UniversalMetricListener consumer2;
+
+  @Autowired
+  @Qualifier("consumer3")
+  UniversalMetricListener consumer3;
+
+  @Autowired
+  EmbeddedKafkaBroker embeddedKafka;
+
+  @MockBean
+  UniversalMetricHandler handler;
+
+  @MockBean
+  ConsumerSeekCallback consumerSeek;
+
+  @Test
+  public void testInitialStartup_1consumer() {
+    consumer1.start();
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(0, 1, 2));
+    verify(handler, timeout(testTimeout)).removeTasksForPartitions(Collections.emptySet());
+    verifyNoMoreInteractions(handler);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).hasSize(3);
+    assertThat(consumer1.getCurrentAssignedPartitions()).isEqualTo(consumer1.getTrackedPartitions());
+  }
+
+  @Test
+  public void testInitialStartup_2consumers() {
+    consumer1.start();
+    consumer2.start();
+
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(0, 2));
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(1));
+    verify(handler, timeout(testTimeout).times(2)).removeTasksForPartitions(Collections.emptySet());
+    verifyNoMoreInteractions(handler);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).hasSize(2);
+    assertThat(consumer2.getCurrentAssignedPartitions()).hasSize(1);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).isEqualTo(consumer1.getTrackedPartitions());
+    assertThat(consumer2.getCurrentAssignedPartitions()).isEqualTo(consumer2.getTrackedPartitions());
+  }
+
+  @Test
+  public void testInitialStartup_3consumers() {
+    consumer1.start();
+    consumer2.start();
+    consumer3.start();
+
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(0));
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(1));
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(2));
+    verify(handler, timeout(testTimeout).times(3)).removeTasksForPartitions(Collections.emptySet());
+    verifyNoMoreInteractions(handler);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).hasSize(1);
+    assertThat(consumer2.getCurrentAssignedPartitions()).hasSize(1);
+    assertThat(consumer2.getCurrentAssignedPartitions()).hasSize(1);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).isEqualTo(consumer1.getTrackedPartitions());
+    assertThat(consumer2.getCurrentAssignedPartitions()).isEqualTo(consumer2.getTrackedPartitions());
+    assertThat(consumer3.getCurrentAssignedPartitions()).isEqualTo(consumer3.getTrackedPartitions());
+  }
+
+  @Test
+  public void testReassignments_addingConsumers() {
+    consumer1.start();
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(0, 1, 2));
+    verify(handler, timeout(testTimeout)).removeTasksForPartitions(Collections.emptySet());
+    verifyNoMoreInteractions(handler);
+    reset(handler);
+
+    consumer2.start();
+    // consumer1 adds 0 partitions and removes 1
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Collections.emptySet());
+    verify(handler, timeout(testTimeout)).removeTasksForPartitions(Set.of(1));
+    // consumer2 adds 1 partition and removes 0
+    verify(handler, timeout(testTimeout)).deployTasksForPartitions(Set.of(1));
+    verify(handler, timeout(testTimeout)).removeTasksForPartitions(Collections.emptySet());
+
+    verifyNoMoreInteractions(handler);
+    reset(handler);
+
+    consumer3.start();
+    // sticky partition assignment means a consumer with only 2 more partitions than another
+    // will not release any partitions
+    verifyNoMoreInteractions(handler);
+    reset(handler);
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).hasSize(2);
+    assertThat(consumer2.getCurrentAssignedPartitions()).hasSize(1);
+    assertThat(consumer3.getCurrentAssignedPartitions()).isEmpty();
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).isEqualTo(consumer1.getTrackedPartitions());
+    assertThat(consumer2.getCurrentAssignedPartitions()).isEqualTo(consumer2.getTrackedPartitions());
+    assertThat(consumer3.getCurrentAssignedPartitions()).isEqualTo(consumer3.getTrackedPartitions());
+  }
+
+  @Test
+  public void testReassignments_removingConsumers() {
+    consumer1.start();
+    consumer2.start();
+    consumer3.start();
+
+    verify(handler, timeout(testTimeout).times(3)).deployTasksForPartitions(anySet());
+    verify(handler, timeout(testTimeout).times(3)).removeTasksForPartitions(anySet());
+    reset(handler);
+
+    consumer1.stop();
+    // rebalance is triggered and hits all consumers
+    // but that doesn't mean all partitions are moved (due to sticky assignment)
+    verify(handler, timeout(testTimeout).times(3)).deployTasksForPartitions(anySet());
+    verify(handler, timeout(testTimeout).times(3)).removeTasksForPartitions(anySet());
+
+    assertThat(consumer1.getCurrentAssignedPartitions()).isEmpty();
+    assertThat(consumer2.getCurrentAssignedPartitions()).hasSize(2);
+    assertThat(consumer3.getCurrentAssignedPartitions()).hasSize(1);
+
+    assertThat(consumer1.getTrackedPartitions()).isEmpty();
+    assertThat(consumer2.getCurrentAssignedPartitions()).isEqualTo(consumer2.getTrackedPartitions());
+    assertThat(consumer3.getCurrentAssignedPartitions()).isEqualTo(consumer3.getTrackedPartitions());
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/UniversalMetricListenerTest.java
@@ -46,6 +46,15 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+/**
+ * These tests verify the coming and going of different consumers.
+ *
+ * The partition re-assignment algorithm appears to be consistent which allows us to
+ * hardcode the assertion values in each test.
+ * Without that our assertions would have to be much more generalized.
+ *
+ * Test will fail if either the number of partitions or the partition strategy is changed.
+ */
 @Slf4j
 @RunWith(SpringRunner.class)
 @EmbeddedKafka(partitions = 3, topics = {"telemetry.metrics.json"})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,0 @@
-spring:
-  profiles:
-    active:
-      test


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-1037

# What

Updates the Kafka Consumer that listens to the metrics topic so that it is now notified of any partition reassignments.

# How

It implements `ConsumerSeekAware` (I tried to use `ConsumerRebalanceListener` but it didn't appear to notify of partitions assigned at startup).

Whenever a consumer enters or exits the consumerGroup all affected consumers will be notified via the `onPartitionsAssigned` and `onPartitionsRevoked` methods.  Rather than immediately taking action on this, a task is scheduled sometime in the future using `ScheduledExecutorService`.  If more partition changes occur before that task has been able to run, then it is delayed by the same amount of time again - this allows for us to wait until consumers are stable before shuffling around tasks.

Once the consumers have stabilized and the task is executed, it will trigger the `event-engine-processor` to determine which partitions have been added and which have been removed and call handler methods to remove the old ones from esper and deploy the new ones.  All tasks in the newly assigned partitions will be loaded directly from MySQL to be converted to Esper and deployed (this final step will be inserted using the logic George is currently working on).

## How to test

Tests have been added to `UniversalMetricListenerTest` to simulate consumers coming and going.

# Why

This should mean limited manual interaction is needed when adding or removing `event-engine-processor` instances.  if we wish to expand the amount of instances we have deployed, we can simply push them out and the distribution of metrics/tasks will happen automatically.

See https://github.com/Rackspace-Segment-Support/salus-docs-internal/blob/master/proposals/event-engine/esper-event-engine-design.md for more info.

# TODO

As mentioned, this doesn't actually deploy/undeploy to esper right now.  That will come soon.

We also need to add consumers for monitor/task change events and add similar (un)deploy logic to those.  This will also be handled in a new PR.