### PR TITLE
load esper queries from db

### DIFF
--- a/src/main/java/com/rackspace/salus/event/processor/engine/EsperEngine.java
+++ b/src/main/java/com/rackspace/salus/event/processor/engine/EsperEngine.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.event.processor.engine;
 
+import static org.springframework.util.CollectionUtils.isEmpty;
+
 import com.espertech.esper.common.client.EPCompiled;
 import com.espertech.esper.common.client.configuration.Configuration;
 import com.espertech.esper.common.client.fireandforget.EPFireAndForgetPreparedQuery;
@@ -35,6 +37,9 @@ import com.rackspace.salus.event.processor.model.SalusEnrichedMetric;
 import com.rackspace.salus.event.processor.services.EsperEventsListener;
 import com.rackspace.salus.event.processor.services.StateEvaluator;
 import com.rackspace.salus.event.processor.services.TaskWarmthTracker;
+import com.rackspace.salus.telemetry.entities.EventEngineTask;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -45,10 +50,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class EsperEngine {
 
-  private EPRuntime runtime;
-  private Configuration config;
+  private final EPRuntime runtime;
+  private final Configuration config;
   private TaskWarmthTracker taskWarmthTracker;
-  private EsperEventsListener esperEventsListener;
+  private final EsperEventsListener esperEventsListener;
 
   @Autowired
   public EsperEngine(TaskWarmthTracker taskWarmthTracker,
@@ -127,6 +132,7 @@ public class EsperEngine {
     }
   }
 
+  @SuppressWarnings("SameParameterValue")
   EPFireAndForgetQueryResult runOnDemandQuery(String epl) {
     return runOnDemandQuery(runtime, config, epl);
   }
@@ -170,5 +176,53 @@ public class EsperEngine {
   public void sendMetric(EnrichedMetric metric) {
     log.trace("Sending metric to esper engine, {}", metric);
     runtime.getEventService().sendEventBean(metric, metric.getClass().getSimpleName());
+  }
+
+  public String createTaskEpl(EventEngineTask t) {
+    String taskId = t.getId().toString();
+    String tenantId = t.getTenantId();
+    // create "tags('os')='linux' and tags('metric')='something'" string
+    Map<String, String> labelSelectors = t.getTaskParameters().getLabelSelector();
+    String tagsString = "";
+    if (!isEmpty(labelSelectors)) {
+      tagsString = t.getTaskParameters().getLabelSelector().entrySet().stream().
+        map(e -> "tags('" + e.getKey() + "')='" + e.getValue() + "'").
+        collect(Collectors.joining(" and "));
+      if (tagsString.length() > 0) {
+        tagsString = " and " + tagsString;
+      }
+    }
+    String eplTemplate = "@name('%s:%s')\n" +
+        "insert into EntryWindow\n" +
+        "select StateEvaluator.evalMetricState(metric, '%s') " +
+        "from SalusEnrichedMetric(" +
+        // TODO: fix monitoringSystem etc when other fields are added
+        "    monitoringSystem='SALUS' and\n" +
+        "    tenantId='%s'%s) metric;";
+
+    return String.format(eplTemplate, tenantId, taskId,
+        taskId, tenantId, tagsString);
+  }
+
+  public void addTask(EventEngineTask t) {
+    String taskId = t.getId().toString();
+    String eplString = createTaskEpl(t);
+    EPStatement epStatement = compileAndDeployQuery(eplString);
+    StateEvaluator.saveTaskData(taskId, epStatement.getDeploymentId(), t);
+    log.trace("Adding task for tenant={} task={}", t.getTenantId(), taskId);
+  }
+
+  public void removeTask(EventEngineTask t) {
+    String taskId = t.getId().toString();
+    String deploymentId = StateEvaluator.removeTaskData(taskId);
+    if (deploymentId != null) {
+      try {
+        runtime.getDeploymentService().undeploy(deploymentId);
+        log.trace("Removing task for tenant={} task={}", t.getTenantId(), taskId);
+      } catch (EPUndeployException e) {
+        log.trace("Exception removing task for tenant={} task={}, exception message={}",
+          t.getTenantId(), taskId, e.getMessage());
+      }
+    }
   }
 }

--- a/src/main/java/com/rackspace/salus/event/processor/engine/EsperEngine.java
+++ b/src/main/java/com/rackspace/salus/event/processor/engine/EsperEngine.java
@@ -220,7 +220,7 @@ public class EsperEngine {
         runtime.getDeploymentService().undeploy(deploymentId);
         log.trace("Removing task for tenant={} task={}", t.getTenantId(), taskId);
       } catch (EPUndeployException e) {
-        log.trace("Exception removing task for tenant={} task={}, exception message={}",
+        log.trace("Exception removing task for tenant={} task={} exception message={}",
           t.getTenantId(), taskId, e.getMessage());
       }
     }

--- a/src/main/java/com/rackspace/salus/event/processor/model/EsperTaskData.java
+++ b/src/main/java/com/rackspace/salus/event/processor/model/EsperTaskData.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.processor.model;
+import lombok.Data;
+import com.rackspace.salus.telemetry.entities.EventEngineTask;
+import lombok.NonNull;
+
+@Data
+public class EsperTaskData {
+  @NonNull
+  String deploymentId;
+  @NonNull
+  EventEngineTask eventEngineTask;
+}

--- a/src/main/java/com/rackspace/salus/event/processor/services/StateEvaluator.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/StateEvaluator.java
@@ -16,34 +16,272 @@
 
 package com.rackspace.salus.event.processor.services;
 
+import com.google.protobuf.Timestamp;
+import com.rackspace.monplat.protocol.Metric;
+import com.rackspace.monplat.protocol.Metric.ValueCase;
+import com.rackspace.salus.event.processor.model.EsperTaskData;
 import com.rackspace.salus.event.processor.model.SalusEnrichedMetric;
+import com.rackspace.salus.telemetry.entities.EventEngineTask;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.Comparator;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.Expression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalExpression.Operator;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.StateExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.TaskState;
+import com.rackspace.salus.telemetry.model.MetricExpressionBase;
+import com.rackspace.salus.telemetry.model.PercentageEvalNode;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class StateEvaluator {
 
-  /**
-   * This method will be used within the Esper query that is added to the engine for each
-   * task loaded.
-   *
-   * @param metric
-   * @param taskId
-   * @param state
-   * @param stateCounts
-   * @return
-   */
-  // TODO this is only an example of what will be used. It will be finalized in future PRs
-  public static SalusEnrichedMetric generateEnrichedMetric(
-      SalusEnrichedMetric metric, UUID taskId, String state, Map<String, Integer> stateCounts) {
+  private static final Map<String, EsperTaskData> taskDataMap = new ConcurrentHashMap<>();
+  private static final Map<Comparator, BiFunction<Double, Double, Boolean>> numericCompareFunctions =
+      Map.of(Comparator.EQUAL_TO, Double::equals,
+             Comparator.NOT_EQUAL_TO, (op1, op2)->(!op1.equals(op2)),
+             Comparator.LESS_THAN, (op1, op2)->(op1 < op2),
+             Comparator.LESS_THAN_OR_EQUAL_TO, (op1, op2)->(op1 <= op2),
+             Comparator.GREATER_THAN, (op1, op2)->(op1 > op2),
+             Comparator.GREATER_THAN_OR_EQUAL_TO, (op1, op2)->(op1 >= op2));
+
+  private static Boolean matchRegex(String s, String pattern) {
+    Pattern p = Pattern.compile(pattern);
+    Matcher m = p.matcher(s);
+    return m.find();
+  }
+
+  private static final Map<Comparator, BiFunction<String, String, Boolean>> stringCompareFunctions =
+      Map.of(Comparator.REGEX_MATCH, StateEvaluator::matchRegex,
+             Comparator.NOT_REGEX_MATCH, (op1, op2)->!StateEvaluator.matchRegex(op1, op2));
+
+  public static void saveTaskData(String taskId, String deploymentId, EventEngineTask task) {
+    taskDataMap.put(taskId, new EsperTaskData(deploymentId, task));
+  }
+
+  public static String removeTaskData(String taskId) {
+    EsperTaskData taskData = taskDataMap.remove(taskId);
+    if (taskData == null) {
+      log.warn("Could not remove task data for task={}", taskId);
+      return null;
+    }
+    return taskData.getDeploymentId();
+  }
+
+  private static SalusEnrichedMetric setMetricFields(SalusEnrichedMetric metric, String state,
+      String taskId) {
     return metric
         .setState(state)
-        .setTaskId(taskId)
-        .setExpectedStateCounts(stateCounts)
+        .setTaskId(UUID.fromString(taskId))
         // TODO use metric timestamps instead of `now`` ?
         .setStateEvaluationTimestamp(Instant.now());
   }
 
+  public static SalusEnrichedMetric evalMetricState(SalusEnrichedMetric metric, String taskId) {
+    EsperTaskData data = taskDataMap.get(taskId);
+
+    //prep custom metrics
+    List<Metric> metricList = metric.getMetrics();
+
+    // Todo: send these to UMB
+    List<Metric> evaluatedCustomMetricList = new ArrayList<>();
+
+    List<MetricExpressionBase> customMetrics =
+        data.getEventEngineTask().getTaskParameters().getCustomMetrics();
+    if (customMetrics != null) {
+      for (MetricExpressionBase customMetric : customMetrics) {
+        try {
+          evaluatedCustomMetricList.add(evalCustomMetric(customMetric, metricList));
+        } catch (IllegalArgumentException e) {
+          log.warn("Bad metric parameter used: {}", e.getMessage());
+          return setMetricFields(metric, "CRITICAL", taskId);
+        }
+      }
+    }
+    if (evaluatedCustomMetricList.size() > 0) {
+      metricList.addAll(evaluatedCustomMetricList);
+    }
+    // sort state expressions
+    Map<TaskState, StateExpression> stateExpressions = new HashMap<>();
+    for (StateExpression stateExpression : data.getEventEngineTask().getTaskParameters()
+        .getStateExpressions()) {
+      stateExpressions.put(stateExpression.getState(), stateExpression);
+    }
+
+    // Check each type of stateExpression and return the first one that is true
+    for (String state : List.of("CRITICAL", "WARNING", "OK")) {
+      StateExpression current = stateExpressions.get(TaskState.valueOf(state));
+      try {
+        if (current != null && getExpressionValue(current, metric)) {
+          return setMetricFields(metric, state, taskId);
+        }
+      } catch (IllegalArgumentException e) {
+        log.warn("Bad metric parameter used: {}", e.getMessage());
+        return setMetricFields(metric, "CRITICAL", taskId);
+      }
+    }
+    // None were true so return ok
+    return setMetricFields(metric, "OK", taskId);
+  }
+
+  private static boolean getExpressionValue(StateExpression current,
+      SalusEnrichedMetric metric) {
+    return getExpressionValue(current.getExpression(), metric);
+  }
+
+  private static boolean getExpressionValue(Expression current,
+      SalusEnrichedMetric metric) {
+    if (current instanceof LogicalExpression) {
+      return getLogicalValue((LogicalExpression) current, metric);
+    } else {
+      return getComparisonValue((ComparisonExpression) current, metric);
+    }
+  }
+
+  private static boolean getLogicalValue(LogicalExpression expression,
+      SalusEnrichedMetric metric) {
+    // With Operator.AND return as soon as false is found
+    if (expression.getOperator() == Operator.AND) {
+      for (Expression subExpression : expression.getExpressions()) {
+        if (!getExpressionValue(subExpression, metric))
+          return false;
+      }
+      return true;  // Operator.AND is true if all are true
+    } else {      // With Operator.OR, return as soon as true is found
+      for (Expression subExpression : expression.getExpressions()) {
+        if (getExpressionValue(subExpression, metric))
+          return true;
+      }
+      return false; // Operator.OR is false if all are false
+    }
+  }
+
+  private static boolean getComparisonValue(ComparisonExpression expression,
+      SalusEnrichedMetric metric) {
+    if (stringCompareFunctions.containsKey(expression.getComparator())) {
+      return getStringValue(expression, metric);
+    } else {
+      return getNumericValue(expression, metric);
+    }
+  }
+
+  private static boolean getNumericValue(ComparisonExpression expression,
+      SalusEnrichedMetric metric) {
+    Double operand1 = null, operand2;
+    // Find first operand in metrics and convert to double
+    for (Metric m : metric.getMetrics()) {
+      operand1 = getNumericOperandFromMetric(m, expression.getValueName());
+      if (operand1 != null)
+        break;
+    }
+    if (operand1 == null) {
+      throw new IllegalArgumentException("missing/incorrect type for operand in Metrics: "
+          + expression.getValueName());
+    }
+
+    // Find second operand from comparisionValue and convert to double
+    operand2 = getNumericOperandFromExpression(expression);
+    return numericCompareFunctions.get(expression.getComparator()).apply(operand1, operand2);
+  }
+
+  private static Double getNumericOperandFromMetric(Metric m, String name) {
+    if (m.getName().equals(name)) {
+      if (m.getValueCase() == ValueCase.INT) {
+        return (double) m.getInt();
+      } else if (m.getValueCase() == ValueCase.FLOAT){
+        return m.getFloat();
+      }
+    }
+    return null;
+  }
+
+  private static Double getNumericOperandFromExpression(ComparisonExpression expression) {
+    if (expression.getComparisonValue() instanceof Integer) {
+      return ((Integer) expression.getComparisonValue()).doubleValue();
+    } else if (expression.getComparisonValue() instanceof Double) {
+      return (Double)expression.getComparisonValue();
+    } else {
+      throw new IllegalArgumentException("Illegal comparison object for: " +
+          expression.getValueName());
+    }
+  }
+  
+  private static boolean getStringValue(ComparisonExpression expression,
+      SalusEnrichedMetric metric) {
+    // Find first operand in metrics and make sure it is string
+    String operand1 = null, operand2;
+    for (Metric m : metric.getMetrics()) {
+      operand1 = getStringOperandFromMetric(m, expression.getValueName());
+      if (operand1 != null)
+        break;
+    }
+    if (operand1 == null) {
+      throw new IllegalArgumentException("missing/incorrect type for operand in Metrics: " +
+          expression.getValueName());
+    }
+
+    // Find second operand from comparisionValue and make sure it is string
+    operand2 = getStringOperandFromExpression(expression);
+    return stringCompareFunctions.get(expression.getComparator()).apply(operand1, operand2);
+  }
+
+  private static String getStringOperandFromMetric(Metric m, String name) {
+    if (m.getName().equals(name)) {
+      if (m.getValueCase() ==  ValueCase.STRING) {
+        return m.getString();
+      }
+    }
+    return null;
+  }
+
+  private static String getStringOperandFromExpression(ComparisonExpression expression) {
+    if (expression.getComparisonValue() instanceof String) {
+      return (String) expression.getComparisonValue();
+    } else {
+      throw new IllegalArgumentException("Illegal comparison object for: " +
+          expression.getValueName());
+    }
+  }
+
+  // Generate the synthetic metrics, (currently just percent)
+  static private Metric evalCustomMetric(MetricExpressionBase node, List<Metric>metrics) {
+    Double part = null, total = null;
+    double percentage;
+    Timestamp timestamp = null;
+    if (!(node instanceof PercentageEvalNode)) {
+      throw new IllegalArgumentException("percent is the only custom metric currently supported.");
+    }
+    PercentageEvalNode percentageEvalNode = (PercentageEvalNode)node;
+    // get the partial value
+    for (Metric metric : metrics) {
+      if (part == null) {
+        part = getNumericOperandFromMetric(metric, percentageEvalNode.getPart());
+        if (part != null)
+          timestamp = metric.getTimestamp();
+      }
+      if (total == null)
+        total = getNumericOperandFromMetric(metric, percentageEvalNode.getTotal());
+
+      // calculate the percent
+      if (part != null && total != null) {
+        percentage = part / total * 100;
+        return Metric
+                .newBuilder()
+                .setName(percentageEvalNode.getAs())
+                .setFloat(percentage)
+                .setTimestamp(timestamp).build();
+      }
+    }
+    throw new IllegalArgumentException("percentage part/total not found in metric.");
+  }
 }

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
@@ -52,6 +52,7 @@ public class UniversalMetricHandler {
   private final EsperEngine esperEngine;
   private final SalusEventEngineTaskRepository salusTaskRepository;
 
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   public UniversalMetricHandler(EsperEngine esperEngine,
       SalusEventEngineTaskRepository salusTaskRepository) {
@@ -76,8 +77,11 @@ public class UniversalMetricHandler {
     String accountType = universalMetric.getAccountType().toString();
 
     // TODO : utilize these in the metric payload once umb enrichment is populating the values
+    @SuppressWarnings("unused")
     String deviceId = universalMetric.getDeviceMetadataOrDefault(SALUS_DEVICE_ID_KEY, UNKNOWN_VALUE);
+    @SuppressWarnings("unused")
     String deviceName = universalMetric.getDeviceMetadataOrDefault(SALUS_DEVICE_NAME_KEY, UNKNOWN_VALUE);
+    @SuppressWarnings("unused")
     String deviceDc = universalMetric.getDeviceMetadataOrDefault(SALUS_DEVICE_DC_KEY, UNKNOWN_VALUE);
 
     String resourceId = universalMetric.getSystemMetadataOrThrow(SALUS_RESOURCE_ID_KEY);
@@ -113,7 +117,9 @@ public class UniversalMetricHandler {
       List<SalusEventEngineTask> tasks = salusTaskRepository.findByPartition(partition);
       tasksToUndeploy.addAll(tasks);
     }
-    log.info("TODO Remove tasks from {}", tasksToUndeploy);
+    for (EventEngineTask eventEngineTask : tasksToUndeploy) {
+      esperEngine.removeTask(eventEngineTask);
+    }
   }
 
   /**
@@ -129,6 +135,8 @@ public class UniversalMetricHandler {
       List<SalusEventEngineTask> tasks = salusTaskRepository.findByPartition(partition);
       tasksToDeploy.addAll(tasks);
     }
-    log.info("TODO deploy tasks from {}", tasksToDeploy);
+    for (SalusEventEngineTask salusEventEngineTask : tasksToDeploy) {
+      esperEngine.addTask(salusEventEngineTask);
+    }
   }
 }

--- a/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
+++ b/src/main/java/com/rackspace/salus/event/processor/services/UniversalMetricHandler.java
@@ -135,8 +135,8 @@ public class UniversalMetricHandler {
       List<SalusEventEngineTask> tasks = salusTaskRepository.findByPartition(partition);
       tasksToDeploy.addAll(tasks);
     }
-    for (SalusEventEngineTask salusEventEngineTask : tasksToDeploy) {
-      esperEngine.addTask(salusEventEngineTask);
+    for (EventEngineTask eventEngineTask : tasksToDeploy) {
+      esperEngine.addTask(eventEngineTask);
     }
   }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,7 +1,7 @@
 salus:
   event-processor:
     kafka-listener-auto-start: false
-    partition-assignment-delay: "PT5S"
+    partition-assignment-delay: "PT10S"
 
 logging:
   level:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,7 +1,7 @@
 salus:
   event-processor:
     kafka-listener-auto-start: false
-    partition-assignment-delay: "PT10S"
+    partition-assignment-delay: "PT5S"
 
 logging:
   level:

--- a/src/test/java/com/rackspace/salus/event/processor/services/StateEvaluatorTest.java
+++ b/src/test/java/com/rackspace/salus/event/processor/services/StateEvaluatorTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.processor.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Timestamp;
+import com.rackspace.monplat.protocol.Metric;
+import com.rackspace.salus.event.processor.model.SalusEnrichedMetric;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.Comparator;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.ComparisonExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.LogicalExpression.Operator;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.StateExpression;
+import com.rackspace.salus.telemetry.entities.EventEngineTaskParameters.TaskState;
+import com.rackspace.salus.telemetry.entities.subtype.SalusEventEngineTask;
+import com.rackspace.salus.telemetry.model.MetricExpressionBase;
+import com.rackspace.salus.telemetry.model.PercentageEvalNode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class StateEvaluatorTest {
+
+  // default value for integer metrics
+  static int VALUE = 5;
+
+  List<ComparisonExpression> trueList = List.of(
+      genCompExpression("total_cpu", Comparator.LESS_THAN, VALUE + 1),
+      genCompExpression("total_cpu", Comparator.LESS_THAN_OR_EQUAL_TO, VALUE),
+      genCompExpression("total_cpu", Comparator.GREATER_THAN, VALUE - 1),
+      genCompExpression("total_cpu", Comparator.GREATER_THAN_OR_EQUAL_TO, VALUE),
+      genCompExpression("total_cpu", Comparator.EQUAL_TO, VALUE),
+      genCompExpression("total_cpu", Comparator.NOT_EQUAL_TO, VALUE - 1));
+
+  List<ComparisonExpression> falseList = List.of(
+      genCompExpression("total_cpu", Comparator.LESS_THAN, VALUE),
+      genCompExpression("total_cpu", Comparator.LESS_THAN_OR_EQUAL_TO, VALUE - 1),
+      genCompExpression("total_cpu", Comparator.GREATER_THAN, VALUE),
+      genCompExpression("total_cpu", Comparator.GREATER_THAN_OR_EQUAL_TO, VALUE + 1),
+      genCompExpression("total_cpu", Comparator.EQUAL_TO, VALUE - 1),
+      genCompExpression("total_cpu", Comparator.NOT_EQUAL_TO, VALUE));
+
+  List<ComparisonExpression> trueStringList = List.of(
+      genCompExpression("banner", Comparator.REGEX_MATCH, "a.*z"),
+      genCompExpression("banner", Comparator.NOT_REGEX_MATCH, "a.*1"));
+
+  List<ComparisonExpression> falseStringList = List.of(
+      genCompExpression("banner", Comparator.REGEX_MATCH, "a.*1"),
+      genCompExpression("banner", Comparator.NOT_REGEX_MATCH, "a.*z"));
+
+  private ComparisonExpression genCompExpression(String valueName, Comparator comparator,
+      Object comparisonValue) {
+    return new ComparisonExpression()
+      .setComparator(comparator)
+      .setValueName(valueName)
+      .setComparisonValue(comparisonValue);
+  }
+
+  @Test
+  public void criticalTest() {
+    // critical is true for each
+    for (ComparisonExpression comparisonExpression : trueList) {
+      String taskId = setTaskData(comparisonExpression);
+      SalusEnrichedMetric s = getSalusEnrichedMetric();
+      SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+      assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+    }
+  }
+
+  @Test
+  public void okTest() {
+    // critical is false for each
+    for (ComparisonExpression comparisonExpression : falseList) {
+      String taskId = setTaskData(comparisonExpression);
+      SalusEnrichedMetric s = getSalusEnrichedMetric();
+      SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+      assertThat(generatedMetric.getState()).isEqualTo("OK");
+    }
+  }
+
+  @Test
+  public void criticalStringTest() {
+    // critical is true for each
+    for (ComparisonExpression comparisonExpression : trueStringList) {
+      String taskId = setTaskData(comparisonExpression);
+      SalusEnrichedMetric s = getStringMetric("banner", "abcdz");
+      SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+      assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+    }
+  }
+
+  @Test
+  public void okStringTest() {
+    // critical is false for each
+    for (ComparisonExpression comparisonExpression : falseStringList) {
+      String taskId = setTaskData(comparisonExpression);
+      SalusEnrichedMetric s = getStringMetric("banner", "abcdz");
+      SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+      assertThat(generatedMetric.getState()).isEqualTo("OK");
+    }
+  }
+
+  @Test
+  public void andTest() {
+    // true AND true is critical
+    String taskId = setLogicalTaskData(Operator.AND, trueList);
+    SalusEnrichedMetric s = getSalusEnrichedMetric();
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+
+    // true AND false is ok state
+    taskId = setLogicalTaskData(Operator.AND, List.of(trueList.get(0), falseList.get(0)));
+    s = getSalusEnrichedMetric();
+    generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("OK");
+
+    // false AND false is ok state
+    taskId = setLogicalTaskData(Operator.AND, falseList);
+    s = getSalusEnrichedMetric();
+    generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("OK");
+  }
+
+  @Test
+  public void orTest() {
+    // true OR true is critical
+    String taskId = setLogicalTaskData(Operator.OR, trueList);
+    SalusEnrichedMetric s = getSalusEnrichedMetric();
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+
+    // true OR false is critical
+    taskId = setLogicalTaskData(Operator.OR, List.of(trueList.get(0), falseList.get(0)));
+    s = getSalusEnrichedMetric();
+    generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+
+    // false OR false is ok state
+    taskId = setLogicalTaskData(Operator.OR, falseList);
+    s = getSalusEnrichedMetric();
+    generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    assertThat(generatedMetric.getState()).isEqualTo("OK");
+  }
+
+  @Test
+  public void stringExpressionWithIntegerMetric() {
+    ComparisonExpression comparisonExpression = trueStringList.get(0);
+    String taskId = setTaskData(comparisonExpression, TaskState.OK);
+    SalusEnrichedMetric s = getSalusEnrichedMetric("banner", 3);
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    // Note that even though there is no critical expression it still returns
+    //  critical because of the bad parameter
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+  }      
+
+  @Test
+  public void stringExpressionWithIntegerExpressionValue() {
+    ComparisonExpression comparisonExpression =
+      genCompExpression("banner", Comparator.REGEX_MATCH, 1);
+    String taskId = setTaskData(comparisonExpression, TaskState.OK);
+    SalusEnrichedMetric s = getStringMetric("banner", "valid string");
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    // Note that even though there is no critical expression it still returns
+    //  critical because of the bad parameter
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+  }
+  
+  @Test
+  public void integerExpressionWithStringMetric() {
+    ComparisonExpression comparisonExpression = trueStringList.get(0);
+    String taskId = setTaskData(comparisonExpression, TaskState.OK);
+    SalusEnrichedMetric s = getStringMetric("total_cpu", "bad integer parameter");
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    // Note that even though there is no critical expression it still returns
+    //  critical because of the bad parameter
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+  }
+
+  @Test
+  public void integerExpressionWithStringExpressionValue() {
+    ComparisonExpression comparisonExpression =
+      genCompExpression("total_cpu", Comparator.LESS_THAN, "bad integer value");
+    String taskId = setTaskData(comparisonExpression, TaskState.OK);
+    SalusEnrichedMetric s = getSalusEnrichedMetric("total_cpu", 3);
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, taskId);
+    // Note that even though there is no critical expression it still returns
+    //  critical because of the bad parameter
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+  }
+
+  @Test
+  public void percentageTest() {
+    // Test good parameter
+    percentageTest(30, TaskState.CRITICAL);
+    // Test bad parameter passing in a string instead of an integer
+    percentageTest("bad integer parameter", TaskState.OK);
+  }
+
+  public void percentageTest(Object comparisonValue, TaskState state) {
+    ComparisonExpression comparisonExpression =
+      genCompExpression("percentage", Comparator.LESS_THAN, comparisonValue);
+    PercentageEvalNode node = new PercentageEvalNode().setPart("part").setTotal("total");
+    node.setAs("percentage");
+    List<MetricExpressionBase> list = new ArrayList<>();
+    list.add(node);
+    String t = setTaskData(comparisonExpression, state, list);
+    SalusEnrichedMetric s = getSalusEnrichedMetric("part", 10);
+    Metric total = Metric.newBuilder().setName("total").setInt(100).build();
+    s.getMetrics().add(total);
+    SalusEnrichedMetric generatedMetric = StateEvaluator.evalMetricState(s, t);
+    assertThat(generatedMetric.getState()).isEqualTo("CRITICAL");
+  }
+
+  private SalusEnrichedMetric getSalusEnrichedMetric() {
+    return getSalusEnrichedMetric("total_cpu", VALUE);
+  }
+
+  private SalusEnrichedMetric getSalusEnrichedMetric(String name, int val) {
+    Timestamp timestamp = Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build();
+    Metric m = Metric.newBuilder().setName(name).setInt(val).setTimestamp(timestamp).build();
+    List<Metric> list = new ArrayList<>();
+    list.add(m);
+    SalusEnrichedMetric s =  new SalusEnrichedMetric();
+    s.setMetrics(list);
+    return s;
+  }
+
+  private SalusEnrichedMetric getStringMetric(String name, String val) {
+    Timestamp timestamp = Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build();
+    Metric m = Metric.newBuilder().setName(name).setString(val).setTimestamp(timestamp).build();
+    List<Metric> list = List.of(m);
+    SalusEnrichedMetric s =  new SalusEnrichedMetric();
+    s.setMetrics(list);
+    return s;
+  }
+
+  private String setTaskData(ComparisonExpression comparisonExpression) {
+    return setTaskData(comparisonExpression, TaskState.CRITICAL);
+  }
+
+  private String setTaskData(ComparisonExpression comparisonExpression,
+      TaskState state) {
+    return setTaskData(comparisonExpression, state, null);
+  }
+
+  private String setTaskData(ComparisonExpression comparisonExpression,
+      TaskState state, List<MetricExpressionBase> customMetrics) {
+    String taskId = UUID.randomUUID().toString();
+
+    StateExpression expression = new StateExpression()
+        .setExpression(comparisonExpression)
+        .setState(state);
+    EventEngineTaskParameters parameters =
+        new EventEngineTaskParameters().setStateExpressions(List.of(expression));
+    if (customMetrics != null) {
+      parameters.setCustomMetrics(customMetrics);
+    }
+    SalusEventEngineTask task = new SalusEventEngineTask();
+    task.setTaskParameters(parameters);
+    StateEvaluator.saveTaskData(taskId, "deploymentId", task);
+    return taskId;
+  }
+
+
+  private String setLogicalTaskData(Operator operator,
+      List<ComparisonExpression> comparisonExpressions) {
+    String taskId = UUID.randomUUID().toString();
+    LogicalExpression logicalExpression = new LogicalExpression()
+        .setOperator(operator);
+    //noinspection unchecked
+    logicalExpression.setExpressions((List) comparisonExpressions);
+    StateExpression expression = new StateExpression()
+        .setExpression(logicalExpression)
+        .setState(TaskState.CRITICAL);
+    EventEngineTaskParameters parameters = new EventEngineTaskParameters()
+        .setStateExpressions(List.of(expression));
+    SalusEventEngineTask task = new SalusEventEngineTask();
+    task.setTaskParameters(parameters);
+    StateEvaluator.saveTaskData(taskId, "deploymentId", task);
+    return taskId;
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-1038
https://jira.rax.io/browse/SALUS-1039


# What

Implement metric state calculation logic in event processor.  

Note that this PR is against the jjbuchan/new-consumer branch, not master.

# How

[design](https://github.com/Rackspace-Segment-Support/salus-docs-internal/blob/master/proposals/event-engine/queryLoad.md)

## How to test

run the unit tests


# TODO
1. A number of the UniversalMetricHandler tests seemed to be failing intermittently even before I merged my changes.  We'll need to investigate those.

2. Haven't implemented the "rate" custom metric.  Will create separate PR for that.

3. Haven't made these [additions/removals](https://github.com/Rackspace-Segment-Support/salus-docs-internal/blob/master/proposals/event-engine/queryLoad.md#fields-to-be-modified).  Will create separate PR for that.

4. Not forwarding custom metrics back to the metrics topic. Will create separate PR for that.


# Questions

1. Should the event engine really whether the  monitorScope is remote or local?

2. Should this PR use the [message field in state expression](https://github.com/racker/salus-telemetry-model/blob/58b4639234e74b32fe008fb64c8a00ca7c158904/src/main/java/com/rackspace/salus/telemetry/entities/EventEngineTaskParameters.java#L100)?  It is not currently.


